### PR TITLE
Edge-case handling: ships mit nur einer Pos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /project/project/
 /project/target/
 /target/
+.idea/

--- a/src/main/scala/com/example/PositionOfShips.scala
+++ b/src/main/scala/com/example/PositionOfShips.scala
@@ -1,6 +1,7 @@
 package com.example
 
 import scala.math.{pow, sqrt}
+import scala.util.Try
 
 
 class PositionOfShips(positions: Vector[Position]) {
@@ -28,12 +29,16 @@ class PositionOfShips(positions: Vector[Position]) {
     val totalDistance =
       pos
         .sliding(2)
-        .map { case Vector(a, b) =>
+        .map {
+        case Vector(a) => 0.0
+        case Vector(a, b) =>
           a.position.distance(b.position)
-        }
+      }
         .sum
 
-    totalDistance / pos.head.timeDelta(pos.last)
+    val totalTime = pos.head.timeDelta(pos.last)
+
+    if (totalTime > 0.0) totalDistance / totalTime else 0.0
   }
 
   // Sehr ähnlich wie die Lösung oben, aber mehr mit den "Brot und Butter" Operationen
@@ -47,10 +52,12 @@ class PositionOfShips(positions: Vector[Position]) {
     val totalDistance =
       pos.zip(pos.tail)
         .foldLeft(0.0) { case (total, (a, b)) =>
-          total + a.position.distance(b.position)
-        }
+        total + a.position.distance(b.position)
+      }
 
-    totalDistance / pos.head.timeDelta(pos.last)
+    val totalTime = pos.head.timeDelta(pos.last)
+
+    if (totalTime > 0.0) totalDistance / totalTime else 0.0
   }
 
   // Typischer Hammer in FP, wenn man nicht weiter weiß: Rekursion.
@@ -68,7 +75,9 @@ class PositionOfShips(positions: Vector[Position]) {
         case _ => 0.0 // case _ => else
       }
 
-    totalDistance(pos) / pos.head.timeDelta(pos.last)
+    val totalTime = pos.head.timeDelta(pos.last)
+
+    if (totalTime > 0.0) totalDistance(pos) / totalTime else 0.0
   }
 
   // Und zuletzt die eine imperative Variante
@@ -90,7 +99,10 @@ class PositionOfShips(positions: Vector[Position]) {
     }
 
     // Das Schlüsselwort "return" ist nicht notwendig, just for fun
-    return totalDistance / totalTime
+    if (totalTime > 0.0)
+      return totalDistance / totalTime
+    else
+      return 0.0
   }
 
   def knownShips: Vector[Ship] =

--- a/src/test/scala/com/example/PositionsOfShips.scala
+++ b/src/test/scala/com/example/PositionsOfShips.scala
@@ -52,4 +52,8 @@ class PositionsOfShips extends FlatSpec with Matchers {
   it should "be also smaller than the maximal speed" in {
     avgSpeedOf(Luise) should be < 200.0
   }
+
+  "average speed of Berta" should "be Zero" in {
+    avgSpeedOf(Berta) should be(0.0)
+  }
 }


### PR DESCRIPTION
Mir ist aufgefallen, dass das Zeugs explodiert sobald man einen test mit Berta
inkludiert weil:
- travelTime ist dann immer 0.0 was bei allen `avgSpeedOf` Methoden in einem NaN Rückgabewert endet
- das pattern matching bei der Lösung mit sliding war nicht erschöpfend. Wenn nur eine Position
  im Vector ist gibt es eine (Runtime) Exception (Der Vector sieht dann so aus: `Vector(Vector(Position(...))))`.

Falls du Dich an nen paar Stellen wunderst: 
- Ich hab zwischendurch mal intelij gesagt es soll auto format machen...
- Die code duplizierung ist gewollt.
- Die andere Formatierung der if Anweisung bei der Imparative Lösung ist absichtlich so gewählt.
